### PR TITLE
DPI-3490: Add httr to Imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,6 +12,7 @@ LazyData: TRUE
 VignetteBuilder: knitr
 Imports:
     htmlwidgets,
+    httr,
     base64enc,
     grDevices,
     graphics,


### PR DESCRIPTION
**Problem**
The R CMD CHECK in NixR fails with the following error.
```
ERROR
       >   Namespace dependency missing from DESCRIPTION Imports/Depends entries: 'httr'
       >
       >   See section 'The DESCRIPTION file' in the 'Writing R Extensions'
       >   manual.
       >
       > 1 error x | 0 warnings v | 0 notes v
       > Error: R CMD check found ERRORs
       > Execution halted
```
[Example](https://github.com/Displayr/NixR/actions/runs/16461554468/job/46530072380)

**Solution**
Add `httr` to Imports.